### PR TITLE
tmp

### DIFF
--- a/app/belongs-to-sticky.js
+++ b/app/belongs-to-sticky.js
@@ -1,0 +1,1 @@
+export {default, belongsToSticky, recordHasId} from 'ember-data-has-many-query/belongs-to-sticky';

--- a/app/property-names.js
+++ b/app/property-names.js
@@ -1,0 +1,1 @@
+export {queryParamPropertyName, queryIdPropertyName, lastWasErrorPropertyName, ajaxOptionsPropertyName, stickyPropertyName} from 'ember-data-has-many-query/property-names';


### PR DESCRIPTION
@txm @gczene @deepan83 

addons can use the new import syntax and support older Ember apps as long as their app folders just re-export code under `/addon`

So that PR is a basis for it but must be completely wrong as I'm not good with ES6 import / exports. Someone need to run OAM locally with the branch (I'm on another branch atm for services micro-service task) and fix the code in this PR until it works.
